### PR TITLE
Hide OAuth provider user ID from frontend with opaque ID

### DIFF
--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -17,7 +17,7 @@ app.get("/me", enforce, async (c) => {
   const user = c.get("user");
   return c.json({
     provider: user.provider,
-    id: user.id,
+    id: user.publicId,
     name: user.username,
   });
 });

--- a/server/src/lib/hashgen.ts
+++ b/server/src/lib/hashgen.ts
@@ -25,3 +25,7 @@ export function uniqueId(env: Env, user: { id: string; provider: string }) {
   const { provider, id } = user;
   return hash(`${env.CRYPTO_HASH_KEY}${provider}${id}`, "sha224");
 }
+
+export function publicUserId(env: Env, user: { id: string; provider: string }) {
+  return hmac(`${user.provider}${user.id}`, env.CRYPTO_HASH_KEY, "sha1").slice(0, 10);
+}

--- a/server/src/lib/hashgen.ts
+++ b/server/src/lib/hashgen.ts
@@ -27,5 +27,5 @@ export function uniqueId(env: Env, user: { id: string; provider: string }) {
 }
 
 export function publicUserId(env: Env, user: { id: string; provider: string }) {
-  return hmac(`${user.provider}${user.id}`, env.CRYPTO_HASH_KEY, "sha1").slice(0, 10);
+  return hmac(`${user.provider}:${user.id}`, env.CRYPTO_HASH_KEY, "sha1").slice(0, 10);
 }

--- a/server/src/middleware/enforce.ts
+++ b/server/src/middleware/enforce.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from "hono/factory";
 import { AccessTokenRepository, User } from "../repositories/AccessTokenRepository";
 import { bearerAuth } from "hono/bearer-auth";
+import { publicUserId } from "../lib/hashgen";
 
 type AuthUser = User & { hash: string };
 
@@ -25,7 +26,7 @@ export const enforce = createMiddleware<{
       await tokenRepository.extendExpiration(prefix);
       // Set user in context
       c.set("user", {
-        ...tokenRepository.mapToUser(accessToken),
+        ...tokenRepository.mapToUser(accessToken, publicUserId(c.env, accessToken)),
         hash: prefix,
       });
       // Chain request

--- a/server/src/repositories/AccessTokenRepository.ts
+++ b/server/src/repositories/AccessTokenRepository.ts
@@ -15,6 +15,7 @@ export type AccessToken = {
 
 export type User = {
   id: string;
+  publicId: string;
   provider: string;
   username: string;
   default_username: string;
@@ -68,9 +69,10 @@ export class AccessTokenRepository {
       .where(eq(accessTokensTable.hash, hash));
   }
 
-  mapToUser(token: AccessToken): User {
+  mapToUser(token: AccessToken, publicId: string): User {
     return {
       id: token.id,
+      publicId,
       provider: token.provider,
       username: token.username,
       default_username: token.defaultUsername,


### PR DESCRIPTION
Replace the raw provider user ID in /api/users/me with a 10-character opaque ID derived from HMAC-SHA1(provider+id, CRYPTO_HASH_KEY). This prevents leaking Google/GitHub/etc. internal IDs to clients without requiring any schema changes or new dependencies.