### PR TITLE
Refactor Location to use opaque public ID, clean up map key handling

### DIFF
--- a/client/src/autocomplete.ts
+++ b/client/src/autocomplete.ts
@@ -113,7 +113,7 @@ export default class Autocomplete {
         secondary: `${x.latitude},${x.longitude}`,
         value: x.name,
         type: "person-fill" as const,
-        userId: `${x.provider}:${x.id}`,
+        userId: x.id,
         raw: x,
       }));
   }

--- a/client/src/markers.ts
+++ b/client/src/markers.ts
@@ -4,7 +4,6 @@ import MapView from "./map-view";
 import { createMarkerIcon } from "./marker-icon";
 
 export type Location = {
-  provider: string;
   id: string;
   name: string;
   latitude: number;
@@ -23,7 +22,7 @@ export default class Markers {
   }
 
   update(obj: Location) {
-    const key = `${obj.provider}:${obj.id}`;
+    const key = obj.id;
     const opt = {
       position: new google.maps.LatLng(obj.latitude, obj.longitude),
       icon: createMarkerIcon(obj.heading),

--- a/server/src/api/locations.ts
+++ b/server/src/api/locations.ts
@@ -2,7 +2,7 @@ import { createHono } from "../lib/factory";
 import { Location, Storage, PUBLIC_MAP_KEY } from "../durable-objects/storage";
 import { HTTPException } from "hono/http-exception";
 import { enforce } from "../middleware/enforce";
-import { publicUserId, uniqueId } from "../lib/hashgen";
+import { uniqueId } from "../lib/hashgen";
 
 type UpdateRequestBody = {
   latitude: string;
@@ -23,7 +23,7 @@ app.post("/update", enforce, async (c) => {
   const body = await c.req.parseBody<UpdateRequestBody>();
   const user = c.get("user");
   const obj: Location = {
-    id: publicUserId(c.env, user),
+    id: user.publicId,
     name: user.username,
     latitude: parseFloat(body.latitude),
     longitude: parseFloat(body.longitude),
@@ -61,7 +61,7 @@ app.post("/delete", enforce, async (c) => {
   const group = body.key;
   // delete location
   const stub = Storage.stub(c.env);
-  await stub.deleteLocation(publicUserId(c.env, user), group);
+  await stub.deleteLocation(user.publicId, group);
   return c.text("ok");
 });
 

--- a/server/src/api/locations.ts
+++ b/server/src/api/locations.ts
@@ -51,7 +51,7 @@ app.post("/update", enforce, async (c) => {
   }
   // store location
   const stub = Storage.stub(c.env);
-  await stub.storeLocations(obj, [getPreferredMapKey(c.env, user, isPrivate), ...groups]);
+  await stub.storeLocations(obj, [getPreferredMapKey(c.env, user, isPrivate), ...new Set(groups)]);
   return c.text("ok");
 });
 

--- a/server/src/api/locations.ts
+++ b/server/src/api/locations.ts
@@ -1,7 +1,9 @@
 import { createHono } from "../lib/factory";
-import { Location, Storage } from "../durable-objects/storage";
+import { Location, Storage, PUBLIC_MAP_KEY } from "../durable-objects/storage";
 import { HTTPException } from "hono/http-exception";
 import { enforce } from "../middleware/enforce";
+import { publicUserId, uniqueId } from "../lib/hashgen";
+
 type UpdateRequestBody = {
   latitude: string;
   longitude: string;
@@ -11,22 +13,25 @@ type UpdateRequestBody = {
   key: string;
 };
 
+function getPreferredMapKey(env: Env, user: { id: string; provider: string }, isPrivate: boolean): string {
+  return isPrivate ? uniqueId(env, user) : PUBLIC_MAP_KEY;
+}
+
 const app = createHono();
 
 app.post("/update", enforce, async (c) => {
   const body = await c.req.parseBody<UpdateRequestBody>();
   const user = c.get("user");
   const obj: Location = {
-    provider: user.provider,
-    id: user.id,
+    id: publicUserId(c.env, user),
     name: user.username,
     latitude: parseFloat(body.latitude),
     longitude: parseFloat(body.longitude),
     heading: parseFloat(body.heading) % 360,
     posMode: body.posMode,
   };
-  const group = body.key || "";
   const isPrivate = body.private === "true";
+  const group = body.key || "";
   // check values
   if (isNaN(obj.latitude)) throw new HTTPException(400, { message: "latitude is not a number" });
   if (isNaN(obj.longitude)) throw new HTTPException(400, { message: "longitude is not a number" });
@@ -46,7 +51,7 @@ app.post("/update", enforce, async (c) => {
   }
   // store location
   const stub = Storage.stub(c.env);
-  await stub.storeLocation(obj, groups, isPrivate);
+  await stub.storeLocations(obj, [getPreferredMapKey(c.env, user, isPrivate), ...groups]);
   return c.text("ok");
 });
 
@@ -56,7 +61,7 @@ app.post("/delete", enforce, async (c) => {
   const group = body.key;
   // delete location
   const stub = Storage.stub(c.env);
-  await stub.deleteLocation(user.provider, user.id, group);
+  await stub.deleteLocation(publicUserId(c.env, user), group);
   return c.text("ok");
 });
 

--- a/server/src/api/users.ts
+++ b/server/src/api/users.ts
@@ -1,5 +1,5 @@
 import { HTTPException } from "hono/http-exception";
-import { Storage } from "../durable-objects/storage";
+import { Storage, PUBLIC_MAP_KEY } from "../durable-objects/storage";
 import { createHono } from "../lib/factory";
 import { enforce } from "../middleware/enforce";
 import { uniqueId } from "../lib/hashgen";
@@ -8,7 +8,7 @@ import { AccessTokenRepository } from "../repositories/AccessTokenRepository";
 const app = createHono();
 
 app.get("/show", enforce, async (c) => {
-  const key = c.req.query("key") || "0";
+  const key = c.req.query("key") || PUBLIC_MAP_KEY;
   const stub = Storage.stub(c.env);
   return c.json(await stub.showLocations(key));
 });
@@ -16,7 +16,6 @@ app.get("/show", enforce, async (c) => {
 app.get("/me", enforce, async (c) => {
   const user = c.get("user");
   return c.json({
-    provider: user.provider,
     id: user.publicId,
     name: user.username,
   });

--- a/server/src/durable-objects/connection.ts
+++ b/server/src/durable-objects/connection.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { Location, Storage } from "./storage";
+import { Location, Storage, PUBLIC_MAP_KEY } from "./storage";
 
 export class Connection extends DurableObject<Env> {
   static stub(env: Env, hash: string) {
@@ -16,7 +16,7 @@ export class Connection extends DurableObject<Env> {
 
   async fetch(req: Request) {
     const url = new URL(req.url);
-    await this.setName(url.pathname.split("/")[2] || "0");
+    await this.setName(url.pathname.split("/")[2] || PUBLIC_MAP_KEY);
 
     const websocketPair = new WebSocketPair();
     const [client, server] = Object.values(websocketPair);
@@ -82,7 +82,7 @@ export class Connection extends DurableObject<Env> {
   }
 
   private async getName() {
-    return (await this.ctx.storage.get<string>("name")) || "0";
+    return (await this.ctx.storage.get<string>("name")) || PUBLIC_MAP_KEY;
   }
 
   private async setName(name: string) {

--- a/server/src/durable-objects/storage.ts
+++ b/server/src/durable-objects/storage.ts
@@ -1,10 +1,10 @@
 import { DurableObject } from "cloudflare:workers";
-import { uniqueId } from "../lib/hashgen";
 import { Location, LocationRepository, PrimaryKey } from "../repositories/LocationRepository";
 import { Connection } from "./connection";
 import geo from "../lib/geo";
 
 export { Location } from "../repositories/LocationRepository";
+export const PUBLIC_MAP_KEY = "0";
 
 export class Storage extends DurableObject<Env> {
   static readonly DEFAULT = "default";
@@ -24,8 +24,7 @@ export class Storage extends DurableObject<Env> {
       // すでにExpireしているデータを削除する
       const expirations = await this.locationRepository.listExpirations();
       for (const expired of expirations) {
-        const { provider, id, mapKey } = expired;
-        await this.locationRepository.delete(mapKey, provider, id);
+        await this.locationRepository.delete(expired.mapKey, expired.id);
       }
 
       // 間近のExpireをスケジュールする
@@ -39,33 +38,28 @@ export class Storage extends DurableObject<Env> {
     });
   }
 
-  async storeLocation(obj: Location, groups: string[], isPrivate: boolean) {
-    const primary = isPrivate ? uniqueId(this.env, obj) : "0";
-    await Promise.all([
-      this.updateAndPublish(primary, obj),
-      ...groups.map((group) => this.updateAndPublish(group, obj)),
-    ]);
+  async storeLocations(obj: Location, mapKeys: string[]) {
+    await Promise.all(mapKeys.map((k) => this.updateAndPublish(k, obj)));
   }
 
   async showLocations(group: string) {
-    const key = group || "0";
+    const key = group || PUBLIC_MAP_KEY;
     return await this.locationRepository.listByMapKey(key);
   }
 
-  async deleteLocation(provider: string, id: string, group: string) {
-    const key = group || "0";
+  async deleteLocation(id: string, group: string) {
+    const key = group || PUBLIC_MAP_KEY;
     if (key === "*") {
-      await this.deleteAllAndPublish(provider, id);
+      await this.deleteAllAndPublish(id);
     } else {
-      await this.deleteAndPublish(provider, id, key);
+      await this.deleteAndPublish(id, key);
     }
   }
 
   async alarm() {
     const expirations = await this.locationRepository.listExpirations();
     for (const expired of expirations) {
-      const { provider, id, mapKey } = expired;
-      await this.deleteAndPublish(provider, id, mapKey);
+      await this.deleteAndPublish(expired.id, expired.mapKey);
     }
     await this.schedule();
   }
@@ -77,23 +71,23 @@ export class Storage extends DurableObject<Env> {
     await this.schedule();
   }
 
-  private async deleteAndPublish(provider: string, id: string, group: string) {
-    const removed = await this.locationRepository.delete(group, provider, id);
+  private async deleteAndPublish(id: string, group: string) {
+    const removed = await this.locationRepository.delete(group, id);
     if (!removed) return;
 
     await this.publish("delete", removed);
     await this.schedule();
   }
 
-  private async deleteAllAndPublish(provider: string, id: string) {
-    const removed = await this.locationRepository.deleteAll(provider, id);
+  private async deleteAllAndPublish(id: string) {
+    const removed = await this.locationRepository.deleteAll(id);
     for (const key of removed) {
       await this.publish("delete", key);
     }
   }
 
   private async ensureHeading(group: string, next: Location) {
-    const current = await this.locationRepository.get(group, next.provider, next.id);
+    const current = await this.locationRepository.get(group, next.id);
     if (current == null) return next;
     if (next.heading != null) return next;
     return {

--- a/server/src/repositories/LocationRepository.ts
+++ b/server/src/repositories/LocationRepository.ts
@@ -1,9 +1,7 @@
-export type UserId = `${string}:${string}`;
-export type PrimaryKey = `locations#${string}#${UserId}`;
-export type SecondaryKey = `locations#${UserId}#${string}`;
+export type PrimaryKey = `locations#${string}#${string}`;
+export type SecondaryKey = `locations#${string}#${string}`;
 
 export type Location = {
-  provider: string;
   id: string;
   name: string;
   latitude: number;
@@ -13,7 +11,6 @@ export type Location = {
 };
 
 type Expiration = {
-  provider: string;
   id: string;
   mapKey: string;
   ttl: number;
@@ -24,23 +21,19 @@ type LocationStorageType = Location & {
   ttl: number;
 };
 
-const userId = (provider: string, id: string): UserId => `${provider}:${id}`;
-
-const LocationLifeTime = 5 * 60 * 1000; // 5 minutes
-
 const Keys = {
-  primaryKey: (mapKey: string, provider: string, id: string): PrimaryKey =>
-    `locations#${mapKey}#${userId(provider, id)}`,
-  secondaryKey: (provider: string, id: string, mapKey: string): SecondaryKey =>
-    `locations#${userId(provider, id)}#${mapKey}`,
+  primaryKey: (mapKey: string, id: string): PrimaryKey => `locations#${mapKey}#${id}`,
+  secondaryKey: (id: string, mapKey: string): SecondaryKey => `locations#${id}#${mapKey}`,
   expirationKey: (ttl: number) => `exp#${ttl}`,
 } as const;
 
 const Prefixes = {
   primaryKey: (mapKey: string) => `locations#${mapKey}#`,
-  secondaryKey: (provider: string, id: string) => `locations#${userId(provider, id)}#`,
+  secondaryKey: (id: string) => `locations#${id}#`,
   expirations: () => `exp#`,
 } as const;
+
+const LocationLifeTime = 5 * 60 * 1000; // 5 minutes
 
 export class LocationRepository {
   constructor(private db: DurableObjectStorage) {}
@@ -48,32 +41,18 @@ export class LocationRepository {
   async put(mapKey: string, value: Location) {
     const ttl = Date.now() + LocationLifeTime;
     const storageValue = { ...value, mapKey, ttl };
-    const existing = await this.db.get<LocationStorageType>(
-      Keys.primaryKey(mapKey, value.provider, value.id)
-    );
-    await this.db.put<LocationStorageType>(
-      Keys.primaryKey(mapKey, value.provider, value.id),
-      storageValue
-    );
-    await this.db.put<LocationStorageType>(
-      Keys.secondaryKey(value.provider, value.id, mapKey),
-      storageValue
-    );
-    await this.db.put<Expiration>(`exp#${ttl}`, {
-      provider: value.provider,
-      id: value.id,
-      mapKey,
-      ttl,
-    });
+    const existing = await this.db.get<LocationStorageType>(Keys.primaryKey(mapKey, value.id));
+    await this.db.put<LocationStorageType>(Keys.primaryKey(mapKey, value.id), storageValue);
+    await this.db.put<LocationStorageType>(Keys.secondaryKey(value.id, mapKey), storageValue);
+    await this.db.put<Expiration>(`exp#${ttl}`, { id: value.id, mapKey, ttl });
     if (existing) {
       this.db.delete(Keys.expirationKey(existing.ttl));
     }
-
-    return Keys.primaryKey(mapKey, value.provider, value.id);
+    return Keys.primaryKey(mapKey, value.id);
   }
 
-  async get(mapKey: string, provider: string, id: string) {
-    return await this.db.get<Location>(Keys.primaryKey(mapKey, provider, id));
+  async get(mapKey: string, id: string) {
+    return await this.db.get<Location>(Keys.primaryKey(mapKey, id));
   }
 
   async getNextExpiration() {
@@ -85,42 +64,34 @@ export class LocationRepository {
     return expirations.values().toArray()[0].ttl;
   }
 
-  async delete(mapKey: string, provider: string, id: string) {
-    const key = Keys.primaryKey(mapKey, provider, id);
+  async delete(mapKey: string, id: string) {
+    const key = Keys.primaryKey(mapKey, id);
     const value = await this.db.get<LocationStorageType>(key);
     if (!value) return null;
     this.db.delete(key);
-    this.db.delete(Keys.secondaryKey(provider, id, mapKey));
+    this.db.delete(Keys.secondaryKey(id, mapKey));
     this.db.delete(Keys.expirationKey(value.ttl));
-
     return key;
   }
 
-  async deleteAll(provider: string, id: string) {
-    const key = Prefixes.secondaryKey(provider, id);
+  async deleteAll(id: string) {
+    const prefix = Prefixes.secondaryKey(id);
     const removed: Array<PrimaryKey> = [];
     while (true) {
-      const locations = await this.db.list<LocationStorageType>({ prefix: key });
+      const locations = await this.db.list<LocationStorageType>({ prefix });
       if (locations.size === 0) break;
       for (const [, value] of locations) {
-        await this.db.delete(Keys.primaryKey(value.mapKey, provider, id));
-        await this.db.delete(Keys.secondaryKey(provider, id, value.mapKey));
+        await this.db.delete(Keys.primaryKey(value.mapKey, id));
+        await this.db.delete(Keys.secondaryKey(id, value.mapKey));
         await this.db.delete(Keys.expirationKey(value.ttl));
-        removed.push(Keys.primaryKey(value.mapKey, provider, id));
+        removed.push(Keys.primaryKey(value.mapKey, id));
       }
     }
-
     return removed;
   }
 
   async listByMapKey(mapKey: string) {
     return (await this.db.list<Location>({ prefix: Prefixes.primaryKey(mapKey) }))
-      .values()
-      .toArray();
-  }
-
-  async listByUserId(provider: string, id: string) {
-    return (await this.db.list<Location>({ prefix: Prefixes.secondaryKey(provider, id) }))
       .values()
       .toArray();
   }

--- a/server/src/repositories/LocationRepository.ts
+++ b/server/src/repositories/LocationRepository.ts
@@ -24,13 +24,13 @@ type LocationStorageType = Location & {
 const Keys = {
   primaryKey: (mapKey: string, id: string): PrimaryKey => `locations#${mapKey}#${id}`,
   secondaryKey: (id: string, mapKey: string): SecondaryKey => `locations#${id}#${mapKey}`,
-  expirationKey: (ttl: number) => `exp#${ttl}`,
+  expirationKey: (ttl: number, mapKey: string, id: string) => `exp#${ttl}#${mapKey}#${id}`,
 } as const;
 
 const Prefixes = {
   primaryKey: (mapKey: string) => `locations#${mapKey}#`,
   secondaryKey: (id: string) => `locations#${id}#`,
-  expirations: () => `exp#`,
+  expirationKey: () => `exp#`,
 } as const;
 
 const LocationLifeTime = 5 * 60 * 1000; // 5 minutes
@@ -44,9 +44,9 @@ export class LocationRepository {
     const existing = await this.db.get<LocationStorageType>(Keys.primaryKey(mapKey, value.id));
     await this.db.put<LocationStorageType>(Keys.primaryKey(mapKey, value.id), storageValue);
     await this.db.put<LocationStorageType>(Keys.secondaryKey(value.id, mapKey), storageValue);
-    await this.db.put<Expiration>(`exp#${ttl}`, { id: value.id, mapKey, ttl });
+    await this.db.put<Expiration>(Keys.expirationKey(ttl, mapKey, value.id), { id: value.id, mapKey, ttl });
     if (existing) {
-      this.db.delete(Keys.expirationKey(existing.ttl));
+      await this.db.delete(Keys.expirationKey(existing.ttl, mapKey, value.id));
     }
     return Keys.primaryKey(mapKey, value.id);
   }
@@ -57,7 +57,7 @@ export class LocationRepository {
 
   async getNextExpiration() {
     const expirations = await this.db.list<Expiration>({
-      prefix: Prefixes.expirations(),
+      prefix: Prefixes.expirationKey(),
       limit: 1,
     });
     if (expirations.size === 0) return null;
@@ -68,9 +68,9 @@ export class LocationRepository {
     const key = Keys.primaryKey(mapKey, id);
     const value = await this.db.get<LocationStorageType>(key);
     if (!value) return null;
-    this.db.delete(key);
-    this.db.delete(Keys.secondaryKey(id, mapKey));
-    this.db.delete(Keys.expirationKey(value.ttl));
+    await this.db.delete(key);
+    await this.db.delete(Keys.secondaryKey(id, mapKey));
+    await this.db.delete(Keys.expirationKey(value.ttl, mapKey, id));
     return key;
   }
 
@@ -83,7 +83,7 @@ export class LocationRepository {
       for (const [, value] of locations) {
         await this.db.delete(Keys.primaryKey(value.mapKey, id));
         await this.db.delete(Keys.secondaryKey(id, value.mapKey));
-        await this.db.delete(Keys.expirationKey(value.ttl));
+        await this.db.delete(Keys.expirationKey(value.ttl, value.mapKey, value.id));
         removed.push(Keys.primaryKey(value.mapKey, id));
       }
     }
@@ -98,7 +98,7 @@ export class LocationRepository {
 
   async listExpirations() {
     const now = Date.now();
-    const expirations = await this.db.list<Expiration>({ prefix: Prefixes.expirations() });
+    const expirations = await this.db.list<Expiration>({ prefix: Prefixes.expirationKey() });
     return [...expirations.entries()]
       .filter(([, value]) => value.ttl <= now)
       .map(([, value]) => value);

--- a/server/src/ws/index.ts
+++ b/server/src/ws/index.ts
@@ -1,13 +1,14 @@
 import { cors } from "hono/cors";
 import { Connection } from "../durable-objects/connection";
 import { createHono } from "../lib/factory";
+import { PUBLIC_MAP_KEY } from "../durable-objects/storage";
 
 const app = createHono();
 
 app.use("/api/*", cors({ origin: "*" }));
 
 app.get("/:hash?", (c) => {
-  const hash = c.req.param("hash") || "0";
+  const hash = c.req.param("hash") || PUBLIC_MAP_KEY;
   return Connection.stub(c.env, hash).fetch(c.req.raw);
 });
 


### PR DESCRIPTION
- Remove provider from Location type; use publicUserId (HMAC-based opaque ID) as the sole identifier
- Remove provider from /me response (client already knows which provider it used)
- Rename storeLocation → storeLocations with flat mapKeys[] — primary and group keys are now treated identically
- Export PUBLIC_MAP_KEY from storage.ts as the single source of truth for the default map key "0", replacing magic strings across connection.ts, users.ts, ws/index.ts
- Add getPreferredMapKey local helper in locations.ts to compute the primary map key