### PR TITLE
Migrate to Places API (New) and remove jQuery dependency

### DIFF
--- a/client/src/autocomplete.ts
+++ b/client/src/autocomplete.ts
@@ -1,99 +1,99 @@
+import autocomplete from "autocompleter";
 import Hash from "./hash";
 import type Markers from "./markers";
 import type { Location } from "./markers";
 
-type AutocompleteItem = {
+type Match = { offset: number; length: number };
+
+type Item = {
   label: string;
-  secondary: string;
   value: string;
   type: "person-fill" | "geo-alt-fill";
-  placeId?: string;
-  userId?: string;
-  raw: unknown;
+  mainText: string;
+  secondaryText: string;
+  matches: Match[];
+  placePrediction?: google.maps.places.PlacePrediction;
+  user?: Location;
 };
 
 export default class Autocomplete {
-  private autocomplete: google.maps.places.AutocompleteService;
-  private places: google.maps.places.PlacesService;
-  private element: HTMLElement | null = null;
+  private element: HTMLInputElement | null = null;
+  private sessionToken: google.maps.places.AutocompleteSessionToken | null = null;
 
   constructor(
     private map: google.maps.Map,
     private markers: Markers
-  ) {
-    this.autocomplete = new google.maps.places.AutocompleteService();
-    this.places = new google.maps.places.PlacesService(map);
-  }
+  ) {}
 
   enable(element: HTMLElement) {
-    this.element = element;
-    const source = (req: { term: string }, callback: (data: AutocompleteItem[]) => void) =>
-      this.runQuery(req.term, callback);
-    $(this.element)
-      .autocomplete({
-        source: source,
-        appendTo: ".search-bar",
-        select: (a, b) => this.selectItem(a, b),
-        open: () => {
-          $(".ui-autocomplete").off("hover mouseover mouseenter");
-        },
-      })
-      .data("ui-autocomplete")._renderItem = (ul: JQuery, item: AutocompleteItem) => {
-      const secondary = $(`<span>${item.secondary}</span>`).addClass("secondary");
-      const icon = $("<i>").addClass("bi").addClass(`bi-${item.type}`).attr("aria-hidden", "true");
-      const content = $(`<span>${item.label}</span>`).append(secondary).prepend(icon);
-      const li = $("<li></li>").append(content);
-      li.addClass(`item-${item.type}`);
-      return li.appendTo(ul);
-    };
+    this.element = element as HTMLInputElement;
+    const container = document.createElement("div");
+    container.classList.add("search-autocomplete");
+    document.querySelector(".search-bar")?.appendChild(container);
+
+    autocomplete<Item>({
+      input: this.element,
+      container,
+      className: "search-autocomplete",
+      minLength: 2,
+      debounceWaitMs: 250,
+      preventSubmit: 1,
+      fetch: (text, update) => {
+        void this.runQuery(text, update);
+      },
+      onSelect: (item) => {
+        void this.selectItem(item);
+      },
+      render: (item) => this.renderItem(item),
+    });
   }
 
-  selectItem(_element: JQueryEventObject, ui: JQueryUI.AutocompleteUIParams) {
-    if (ui.item.placeId) {
-      this.places.getDetails({ placeId: ui.item.placeId }, (place) => {
-        if (!place?.geometry) {
-          return;
-        }
-        if (place.geometry.viewport) {
-          this.map.fitBounds(place.geometry.viewport);
-        } else if (place.geometry.location) {
-          this.map.setCenter(place.geometry.location);
-          this.map.setZoom(17);
-        }
-      });
-    } else {
-      Hash.setInfo({ id: ui.item.userId });
-      this.map.setCenter(new google.maps.LatLng(ui.item.raw.latitude, ui.item.raw.longitude));
+  private ensureSession(): google.maps.places.AutocompleteSessionToken {
+    if (!this.sessionToken) {
+      this.sessionToken = new google.maps.places.AutocompleteSessionToken();
     }
-    window.setTimeout(() => $("#focus_trick").focus(), 0);
+    return this.sessionToken;
   }
 
-  runQuery(req: string, callback: (data: AutocompleteItem[]) => void) {
-    this.autocomplete.getPlacePredictions(
-      { input: req, bounds: this.map.getBounds() },
-      (results) => {
-        const users = this.queryUsers(req);
-        const locations = (results || []).map((x) => ({
-          label: this.format(x.structured_formatting),
-          secondary: x.structured_formatting.secondary_text,
-          value: x.description,
+  private async runQuery(req: string, update: (items: Item[] | false) => void) {
+    const users = this.queryUsers(req);
+    try {
+      const bounds = this.map.getBounds();
+      const result = await google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions({
+        input: req,
+        locationBias: bounds ?? undefined,
+        sessionToken: this.ensureSession(),
+      });
+      const locations: Item[] = result.suggestions
+        .map((s) => s.placePrediction)
+        .filter((p): p is google.maps.places.PlacePrediction => p !== null)
+        .map((p) => ({
+          label: p.text.text,
+          value: p.text.text,
           type: "geo-alt-fill" as const,
-          placeId: x.place_id,
-          raw: x,
+          mainText: p.mainText?.text ?? p.text.text,
+          secondaryText: p.secondaryText?.text ?? "",
+          matches: (p.mainText?.matches ?? []).map((m) => ({
+            offset: m.startOffset,
+            length: m.endOffset - m.startOffset,
+          })),
+          placePrediction: p,
         }));
-        callback(users.concat(locations));
-      }
-    );
+      const all = users.concat(locations);
+      update(all.length > 0 ? all : false);
+    } catch {
+      update(users.length > 0 ? users : false);
+    }
   }
 
-  queryUsers(req: string): Array<AutocompleteItem> {
+  private queryUsers(req: string): Item[] {
     const center = this.map.getCenter();
     const reqLower = req.toLowerCase();
     return this.markers
       .values()
       .map((x) => x.rawValue)
       .filter((x): x is Location => x !== undefined)
-      .filter((x) => ~x.name.toLowerCase().indexOf(reqLower))
+      .filter((x) => x.name.toLowerCase().includes(reqLower))
       .sort((a, b) => {
         if (!center) return 0;
         return (
@@ -101,41 +101,77 @@ export default class Autocomplete {
           Math.sqrt((center.lat() - b.latitude) ** 2 + (center.lng() - b.longitude) ** 2)
         );
       })
-      .map((x) => ({
-        label: this.formatUser(req, x.name),
-        secondary: `${x.latitude},${x.longitude}`,
-        value: x.name,
-        type: "person-fill" as const,
-        userId: x.id,
-        raw: x,
-      }));
+      .map((x) => {
+        const offset = x.name.toLowerCase().indexOf(reqLower);
+        const matches: Match[] = offset >= 0 ? [{ offset, length: req.length }] : [];
+        return {
+          label: x.name,
+          value: x.name,
+          type: "person-fill" as const,
+          mainText: x.name,
+          secondaryText: `${x.latitude},${x.longitude}`,
+          matches,
+          user: x,
+        };
+      });
   }
 
-  format(item: {
-    main_text: string;
-    main_text_matched_substrings: Array<{ offset: number; length: number }>;
-  }) {
-    let p = 0;
-    let s = "";
-    for (let i = 0; i < item.main_text_matched_substrings.length; ++i) {
-      const f = item.main_text_matched_substrings[i];
-      if (p < f.offset) {
-        s += item.main_text.substring(p, f.offset - p);
+  private async selectItem(item: Item) {
+    if (item.placePrediction) {
+      try {
+        const place = item.placePrediction.toPlace();
+        await place.fetchFields({ fields: ["viewport", "location"] });
+        if (place.viewport) {
+          this.map.fitBounds(place.viewport);
+        } else if (place.location) {
+          this.map.setCenter(place.location);
+          this.map.setZoom(17);
+        }
+      } catch {
+        // best-effort; failures here don't need to surface to the user
       }
-      s += `<strong>${item.main_text.substring(f.offset, f.offset + f.length)}</strong>`;
-      p = f.offset + f.length;
+    } else if (item.user) {
+      Hash.setInfo({ id: item.user.id });
+      this.map.setCenter(new google.maps.LatLng(item.user.latitude, item.user.longitude));
     }
-    if (p < item.main_text.length) {
-      s += item.main_text.substring(p);
-    }
-    return s;
+    this.sessionToken = null;
+    if (this.element) this.element.value = item.value;
+    window.setTimeout(() => document.getElementById("focus_trick")?.focus(), 0);
   }
 
-  formatUser(req: string, name: string) {
-    const index = name.toLowerCase().indexOf(req);
-    return this.format({
-      main_text: name,
-      main_text_matched_substrings: [{ offset: index, length: req.length }],
-    });
+  private renderItem(item: Item): HTMLDivElement {
+    const row = document.createElement("div");
+    row.className = `autocomplete-item item-${item.type}`;
+
+    const content = document.createElement("span");
+
+    const icon = document.createElement("i");
+    icon.className = `bi bi-${item.type}`;
+    icon.setAttribute("aria-hidden", "true");
+    content.appendChild(icon);
+
+    let pos = 0;
+    for (const m of item.matches) {
+      if (m.offset > pos) {
+        content.appendChild(document.createTextNode(item.mainText.substring(pos, m.offset)));
+      }
+      const strong = document.createElement("strong");
+      strong.textContent = item.mainText.substring(m.offset, m.offset + m.length);
+      content.appendChild(strong);
+      pos = m.offset + m.length;
+    }
+    if (pos < item.mainText.length) {
+      content.appendChild(document.createTextNode(item.mainText.substring(pos)));
+    }
+
+    if (item.secondaryText) {
+      const secondary = document.createElement("span");
+      secondary.className = "secondary";
+      secondary.textContent = item.secondaryText;
+      content.appendChild(secondary);
+    }
+
+    row.appendChild(content);
+    return row;
   }
 }

--- a/client/src/autocomplete.ts
+++ b/client/src/autocomplete.ts
@@ -25,8 +25,8 @@ export default class Autocomplete {
     private markers: Markers
   ) {}
 
-  enable(element: HTMLElement) {
-    this.element = element as HTMLInputElement;
+  enable(element: HTMLInputElement) {
+    this.element = element;
     const container = document.createElement("div");
     container.classList.add("search-autocomplete");
     document.querySelector(".search-bar")?.appendChild(container);

--- a/client/src/map-view.ts
+++ b/client/src/map-view.ts
@@ -62,7 +62,7 @@ export default class MapView {
     return marker;
   }
 
-  enableAutoComplete(element: HTMLElement, markers: Markers) {
+  enableAutoComplete(element: HTMLInputElement, markers: Markers) {
     const autocomplete = new Autocomplete(this.map, markers);
     autocomplete.enable(element);
   }

--- a/client/static/css/map.css
+++ b/client/static/css/map.css
@@ -312,42 +312,42 @@ button.effect:active::before {
 
 /* styles for complexed search implementations */
 
-#search-bar .ui-menu-item {
+#search-bar .autocomplete-item {
   font-size: 16px;
   font-family: "Noto Sans JP";
-}
-
-#search-bar .ui-menu-item > span {
-  display: block;
-  padding: 4px 8px;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-#search-bar .ui-menu-item span.secondary {
-  margin-left: 8px;
-  font-size: 14px;
-  opacity: 0.5;
-}
-
-#search-bar .ui-menu-item {
+  cursor: pointer;
   transition:
     background-color 0.1s,
     color 0.1s;
   color: var(--color);
 }
 
-#search-bar .ui-menu-item i {
+#search-bar .autocomplete-item > span {
+  display: block;
+  padding: 4px 8px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+#search-bar .autocomplete-item span.secondary {
+  margin-left: 8px;
+  font-size: 14px;
+  opacity: 0.5;
+}
+
+#search-bar .autocomplete-item i {
   color: var(--icon-color);
   margin-right: 5px;
 }
 
-#search-bar .ui-menu-item:hover {
+#search-bar .autocomplete-item.selected,
+#search-bar .autocomplete-item:hover {
   background-color: var(--accent);
   color: var(--color-on-accent);
 }
 
-#search-bar .ui-menu-item:hover i {
+#search-bar .autocomplete-item.selected i,
+#search-bar .autocomplete-item:hover i {
   color: var(--color-on-accent);
 }
 
@@ -361,13 +361,15 @@ button.effect:active::before {
   opacity: 0;
 }
 
-.ui-autocomplete {
+.search-autocomplete {
   position: static !important;
   margin-inline: 10px;
   margin-bottom: 10px;
-  left: 0px !important;
+  left: 0 !important;
+  top: auto !important;
   white-space: nowrap;
   width: auto !important;
+  max-height: none !important;
   border-radius: 14px;
   background-color: var(--glass-bg-dd);
   backdrop-filter: blur(20px) saturate(280%);
@@ -376,7 +378,11 @@ button.effect:active::before {
   overflow: hidden;
 }
 
-.ui-autocomplete strong {
+.search-autocomplete:empty {
+  display: none !important;
+}
+
+.search-autocomplete strong {
   font-weight: 700;
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "description": "",
   "dependencies": {
     "@googlemaps/markerwithlabel": "^2.0.28",
+    "autocompleter": "^9.3.2",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.18",
     "typescript": "^5.8.3"
@@ -43,8 +44,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@types/google.maps": "^3.58.1",
-    "@types/jquery": "^3.5.32",
-    "@types/jqueryui": "^1.12.24",
     "@types/node": "^22.14.1",
     "drizzle-kit": "^0.31.0",
     "esbuild": "^0.25.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@googlemaps/markerwithlabel':
         specifier: ^2.0.28
         version: 2.0.28
+      autocompleter:
+        specifier: ^9.3.2
+        version: 9.3.2
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2
@@ -27,12 +30,6 @@ importers:
       '@types/google.maps':
         specifier: ^3.58.1
         version: 3.58.1
-      '@types/jquery':
-        specifier: ^3.5.32
-        version: 3.5.34
-      '@types/jqueryui':
-        specifier: ^1.12.24
-        version: 1.12.24
       '@types/node':
         specifier: ^22.14.1
         version: 22.19.17
@@ -931,17 +928,11 @@ packages:
   '@types/google.maps@3.58.1':
     resolution: {integrity: sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==}
 
-  '@types/jquery@3.5.34':
-    resolution: {integrity: sha512-3m3939S3erqmTLJANS/uy0B6V7BorKx7RorcGZVjZ62dF5PAGbKEDZK1CuLtKombJkFA2T1jl8LAIIs7IV6gBQ==}
-
-  '@types/jqueryui@1.12.24':
-    resolution: {integrity: sha512-E2sGULwzMhg4kAeOV+gYcXjg988RuPkviWCt09jLe6GGK9sHM7dTqS8H7JMuUWoZQBucIBzBAgM5o/ezKUFkeg==}
-
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
-  '@types/sizzle@2.3.10':
-    resolution: {integrity: sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==}
+  autocompleter@9.3.2:
+    resolution: {integrity: sha512-rLbf2TLGOD7y+gOS36ksrZdIsvoHa2KXc2A7503w+NBRPrcF73zzFeYBxEcV/iMPjaBH3jFhNIYObZ7zt1fkCQ==}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
@@ -1688,19 +1679,11 @@ snapshots:
 
   '@types/google.maps@3.58.1': {}
 
-  '@types/jquery@3.5.34':
-    dependencies:
-      '@types/sizzle': 2.3.10
-
-  '@types/jqueryui@1.12.24':
-    dependencies:
-      '@types/jquery': 3.5.34
-
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/sizzle@2.3.10': {}
+  autocompleter@9.3.2: {}
 
   blake3-wasm@2.1.5: {}
 

--- a/server/src/views/Index.tsx
+++ b/server/src/views/Index.tsx
@@ -32,10 +32,6 @@ export const Index: FC<Props> = ({ mapsApiKey }) => {
           />
           <link
             rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css"
-          />
-          <link
-            rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
           />
           <link
@@ -44,14 +40,6 @@ export const Index: FC<Props> = ({ mapsApiKey }) => {
           />
           <link rel="stylesheet" href="/css/map.css" />
           <link rel="prefetch" href="/res/0/0.png" />
-          <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"
-            defer
-          ></script>
-          <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"
-            defer
-          ></script>
           <meta name="color-scheme" content="light dark" />
           <title>LocaPos | Overview</title>
         </head>


### PR DESCRIPTION
Replace deprecated google.maps.places.AutocompleteService and PlacesService with AutocompleteSuggestion + Place APIs, using AutocompleteSessionToken for session-based billing. Replace jQuery UI autocomplete widget with the autocompleter library and rebuild the dropdown UI with vanilla DOM, which also hardens highlight rendering against XSS in user-supplied names. Tune debounceWaitMs and minLength to cap abandoned-session API costs.